### PR TITLE
Improve hyphen case conversion for branch name compliance

### DIFF
--- a/src/jiragit.ts
+++ b/src/jiragit.ts
@@ -43,7 +43,7 @@ function getJiraIssueUrl({ host, key }: { host: string; key: string }) {
 }
 
 function convertToHyphenCase(text: string) {
-  return text.replace(/ +/g, "-").toLowerCase();
+  return text.replace(/\W+/g, "-").toLowerCase();
 }
 
 async function createBranchForExistingIssue({


### PR DESCRIPTION
## Summary

Thanks for considering this pull request. It improves the conversion of task titles to branch names that git accepts.

## Issue

Characters other than space and word in a JIRA task title can cause problems creating a branch in git. For example.
```bash
$ git checkout -tb gone:burger
fatal: 'gone:burger' is not a valid branch name.
```

## Solution

Replace all non-word characters, or runs of, with a single hyphen.