### PR TITLE
Enable configuration of the jql query

### DIFF
--- a/src/jiraConfig.ts
+++ b/src/jiraConfig.ts
@@ -3,4 +3,5 @@ export interface JiraConfig {
   token: string;
   host: string;
   projectKey: string;
+  jql: string;
 }

--- a/src/jiragit.ts
+++ b/src/jiragit.ts
@@ -20,6 +20,8 @@ const DEFAULT_CONFIG: JiraConfig = {
     "TODO: generate in https://id.atlassian.com/manage-profile/security/api-tokens",
   host: "https://mycompany.atlassian.net",
   projectKey: "Example: for issue like ABC-123 ABC is the project key",
+  jql:
+    "assignee in (currentUser()) and sprint in openSprints() and statusCategory in ('To Do') order by created DESC",
 };
 
 const JiraConfigSchema: ZodSchema<JiraConfig> = z.object({
@@ -27,6 +29,7 @@ const JiraConfigSchema: ZodSchema<JiraConfig> = z.object({
   token: z.string(),
   host: z.string().url(),
   projectKey: z.string(),
+  jql: z.string(),
 });
 
 function logInfoData(text: string) {
@@ -54,7 +57,7 @@ async function createBranchForExistingIssue({
   jiraConfig: JiraConfig;
 }) {
   const searchIssues = await jiraClient.issueSearch.searchForIssuesUsingJql({
-    jql: "assignee in (currentUser()) and sprint in openSprints() and statusCategory in ('To Do') order by created DESC",
+    jql: jiraConfig.jql,
     fields: ["summary", "description"],
   });
 


### PR DESCRIPTION
## Summary

Thanks for considering this pull request. This pull request changes the configuration file to include an additional key `predicate` that defaults to the current *jql* hardcoded in `searchForIssuesUsingJql`

## Issue

Changing the ordering, or filtering with other search terms is not currently possible without editing the code. API coders having to filter through devops tasks is one example of this.

## Solution

By augmenting the config to add in *jql* in as a `predicate` key any supported subsetting of tasks in JIRA can be performed.

```json
{

  "predicate": "sprint in openSprints() and statusCategory in ('To Do') and summary ~ API order by created ASC"
}
```
